### PR TITLE
Feature energy flows output refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-Current SUSI version: 0.2.2
-Implemented for ReSie version: 0.11.3
+Current SUSI version: 0.2.3
+Implemented for ReSie version: 0.12.0
+
+# v0.2.3
+* change default for CSV and plot output to new syntax
+* remove coordinates in sim_params as the default should be to get them from a weather file
 
 ## v0.2.2
 * Update and restructure parameters of components HeatPump, GeothermalProbe, GeothermalCollector and BufferTank

--- a/src/export.py
+++ b/src/export.py
@@ -26,8 +26,6 @@ def base_dict():
             "time_step": 900,
             "time_step_unit": "seconds",
             "weather_file_path": "./path/to/dat/or/epw/weather_file.epw",
-            "latitude": 0.0,
-            "longitude": 0.0,
         },
         "components": {}
     }

--- a/src/export.py
+++ b/src/export.py
@@ -16,8 +16,8 @@ def base_dict():
             "auxiliary_info_file": "./output/auxiliary_info.md",
             "sankey_plot": "default",
             "csv_time_unit": "date",
-            "csv_output_keys": "all",
-            "output_plot": "all",
+            "csv_output_keys": "all_incl_flows",
+            "output_plot": "all_incl_flows",
         },
         "simulation_parameters": {
             "start": "01.01.2024 00:00",


### PR DESCRIPTION
- change default for CSV and plot output
- remove coordinates as the default should be to get them from a weather file

STILL TO DO: New definition of output_ref for CHPP and electrolyser! This will be added when media are implementend in susi.